### PR TITLE
Sticky unchecked by default

### DIFF
--- a/src/main/java/hudson/plugins/claim/AbstractClaimBuildAction.java
+++ b/src/main/java/hudson/plugins/claim/AbstractClaimBuildAction.java
@@ -28,7 +28,7 @@ public abstract class AbstractClaimBuildAction<T extends Saveable> extends TestA
 	private boolean claimed;
 	private String claimedBy;
 	private Date claimDate;
-	private boolean transientClaim;
+	private boolean transientClaim = true;
 	
 	protected T owner;
 	
@@ -106,7 +106,7 @@ public abstract class AbstractClaimBuildAction<T extends Saveable> extends TestA
 	public void unclaim() {
 		this.claimed = false;
 		this.claimedBy = null;
-		this.transientClaim = false;
+		this.transientClaim = true;
 		this.claimDate = null;
 		// we remember the reason to show it if someone reclaims this build.
 	}


### PR DESCRIPTION
For us it makes much more sense to have the sticky checkbox unselected by default. The common case for us is that two failures in a row have different causes. Sloppy developers that do not uncheck the sticky checkbox then automatically claim failures they have not caused.

I understand changing the default behavior is a bit problematic on an existing plugin and maybe a global configuration option to set the default is a better solution. That requires a bit more work and hence we run this code now.
