### PR TITLE
Added ability to run a Groovy script when a claim is changed.

### DIFF
--- a/src/main/java/hudson/plugins/claim/ClaimConfig.java
+++ b/src/main/java/hudson/plugins/claim/ClaimConfig.java
@@ -24,6 +24,11 @@ public class ClaimConfig extends GlobalConfiguration {
     private boolean stickyByDefault = true;
 
     /**
+     * Groovy script to be run when a claim is changed.
+     */
+    private String groovyScript;
+
+    /**
      * This human readable name is used in the configuration screen.
      */
     public String getDisplayName() {
@@ -36,6 +41,7 @@ public class ClaimConfig extends GlobalConfiguration {
         // set that to properties and call save().
         sendEmails = formData.getBoolean("sendEmails");
         stickyByDefault = formData.getBoolean("stickyByDefault");
+        groovyScript = formData.getString("groovyScript");
         save();
         return super.configure(req,formData);
     }
@@ -75,6 +81,22 @@ public class ClaimConfig extends GlobalConfiguration {
 	this.stickyByDefault = stickyByDefault;
     }
 
+    /**
+     * This method returns the Groovy script as a String
+     * @return String containing the Groovy script to run when claims are changed.
+     */
+    public String getGroovyScript() {
+        return groovyScript;
+    }
+    
+    /**
+     * Set the Groovy script to run when a claim is changed.
+     * @param val the script to use
+     */
+    public void setGroovyScript(String val) {
+        groovyScript = val;
+    }
+    
     /**
      * get the current claim configuration
      * @return the global claim configuration

--- a/src/main/resources/hudson/plugins/claim/ClaimConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/claim/ClaimConfig/config.jelly
@@ -6,5 +6,9 @@
     <f:entry title="${%StickyByDefault}" field="stickyByDefault" help="/plugin/claim/help-stickyByDefault.html">
       <f:checkbox />
     </f:entry>
+    <f:entry title="${%GroovyScript}" field="groovyScript" help="/plugin/claim/help-groovyScript.html">
+	    <f:textarea checkMethod="post" codemirror-mode="clike"
+	    codemirror-config="mode: 'text/x-groovy', lineNumbers: true, matchBrackets: true, onBlur: function(editor){editor.save()}"/>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/claim/ClaimConfig/config.properties
+++ b/src/main/resources/hudson/plugins/claim/ClaimConfig/config.properties
@@ -1,3 +1,3 @@
 SendEmails=Send emails when assigning/claiming builds
 StickyByDefault=Sets the default value for stickiness when claiming builds
- 
+GroovyScript=The Groovy script to run when claims are changed

--- a/src/main/webapp/help-groovyScript.html
+++ b/src/main/webapp/help-groovyScript.html
@@ -1,0 +1,21 @@
+<div>
+<p>Groovy script to run when claims are changed. The variable <code>action</code> is bound to the
+hudson.plugins.claim.ClaimBuildAction instance for the claim.</p>
+<p>Here is an example that sends messages to the configured Slack channel.</p>
+<pre>
+// send claim changes to Slack
+def build = action.owner
+def notifier = build.project.publishers.find { k, v -&gt; v.class.name == &#39;jenkins.plugins.slack.SlackNotifier&#39; }?.value
+if (notifier) {
+  def slackServiceClass = notifier.class.classLoader.loadClass(&#39;jenkins.plugins.slack.StandardSlackService&#39;)
+  def slackService = slackServiceClass.newInstance(notifier.teamDomain, notifier.authToken, notifier.room)
+  if (action.claimed) {
+    def sticky = action.isSticky() ? &#39;, sticky&#39; : &#39;&#39;
+    def assignedBy = (action.assignedBy == action.claimedBy) ? &#39;&#39; : &quot;, assigned by ${action.assignedBy}&quot;
+    slackService.publish(&quot;${action.claimedBy} claimed: ${build}${sticky}${assignedBy} (&lt;${build.absoluteUrl}|Open&gt;)\n${action.reason}&quot;, &#39;warning&#39;)
+  } else {
+    slackService.publish(&quot;claim dropped for: ${build} (&lt;${build.absoluteUrl}|Open&gt;)&quot;, &#39;danger&#39;)
+  }
+}
+</pre>
+</div>


### PR DESCRIPTION
I made my changed locally again the claim-2.5 label them merged master before creating this pull request.

This change adds a Groovy script section to the claim-plugin global configuration. This script, if not empty, is run whenever a claim is changed. I could enable a solution so https://issues.jenkins-ci.org/browse/JENKINS-3106. Or, at least, address the idea present by kutzi in the last comment in that issue.

We are using these changes to send Slack notifications when a claim changes. An example of that script is included in the help for the Groovy script field in the global configuration.