### PR TITLE
[JENKINS-27091] Compatibility with Jenkins core 1.577 and newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.509.4</version>
+		<version>1.577</version>
 	</parent>
 
 	<artifactId>claim</artifactId>
@@ -52,7 +52,15 @@
 			<version>1.5</version>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>junit</artifactId>
+			<version>1.5</version>
+		</dependency>
+        <dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>matrix-project</artifactId>
+			<version>1.4</version>
+		</dependency>
 	</dependencies>
-</project>  
-  
-
+</project>


### PR DESCRIPTION
Claim plugin relies on the following packages that have been moved to their own plugins and no longer ship with the Jenkins core:
- hudson.tasks.junit - moved to the junit plugin in [1.577](https://jenkins-ci.org/changelog#v1.577)
- hudson.matrix - moved to the matrix-project plugin in [1.561](https://jenkins-ci.org/changelog#v1.561)

Absence of the above dependencies from the pom.xml results in:
- compilation failures
- runtime exceptions should the Claim plugin be installed on Jenkins 1.561 or newer

---

I've set the required Jenkins core to `1.577` in the PR, however if you prefer to rely on an LTS release then `1.580.3` might be more appropriate.

Looking forward to hearing your thoughts!