### PR TITLE
[Fixed JENKINS-28722] Integrate Build-Failure-Analyzer Plugin with Cl…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 *.ipr
 *.ipr
 /bin
+/.idea/
 =======

--- a/pom.xml
+++ b/pom.xml
@@ -62,5 +62,11 @@
 			<artifactId>matrix-project</artifactId>
 			<version>1.4</version>
 		</dependency>
+		<dependency>
+			<groupId>com.sonyericsson.jenkins.plugins.bfa</groupId>
+			<artifactId>build-failure-analyzer</artifactId>
+			<version>1.13.0</version>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/hudson/plugins/claim/ClaimBuildFailureAnalyzer.java
+++ b/src/main/java/hudson/plugins/claim/ClaimBuildFailureAnalyzer.java
@@ -1,0 +1,109 @@
+package hudson.plugins.claim;
+
+import com.sonyericsson.jenkins.plugins.bfa.PluginImpl;
+import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
+import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
+import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
+import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
+import com.sonyericsson.jenkins.plugins.bfa.statistics.StatisticsLogger;
+import hudson.model.AbstractBuild;
+import hudson.model.Run;
+import jenkins.model.Jenkins;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+public class ClaimBuildFailureAnalyzer {
+
+    public static String ERROR = "Default";
+    private static final String matchingFile = "Claim";
+
+    public ClaimBuildFailureAnalyzer(String error) throws Exception {
+        ERROR=error;
+    }
+
+    public static Collection<FailureCause> getFailureCauses() throws Exception {
+        return Jenkins.getInstance().getPlugin(PluginImpl.class).getKnowledgeBase().getCauses();
+    }
+
+    public static boolean isBFAEnabled(){
+        return (Jenkins.getInstance().getPlugin("build-failure-analyzer")!=null && Jenkins.getInstance().getPlugin(PluginImpl.class).isGlobalEnabled());
+    }
+
+    public static HashMap<String, String> getFillReasonMap() throws Exception {
+        HashMap<String, String> map = new HashMap<String, String>();
+        for (FailureCause cause : getFailureCauses()) {
+            map.put(cause.getName(), cause.getDescription());
+        }
+        return map;
+    }
+
+    public static LinkedList<String> getDropdownList() throws Exception {
+        LinkedList<String> list = new LinkedList<String>();
+        for (FailureCause cause : getFailureCauses()) {
+            list.add(cause.getName());
+        }
+        return list;
+    }
+
+    public void createFailAction(Run run) throws Exception {
+        FoundFailureCause newClaimedFailureCause = null;
+        List<FoundIndication> indications = new LinkedList<FoundIndication>();
+        for(FailureCause cause : getFailureCauses()){
+            if(cause.getName().equals(ERROR)) {
+                indications.add(new ClaimIndication((AbstractBuild) run,"Null",matchingFile,"Null"));
+                newClaimedFailureCause = new FoundFailureCause(cause, indications);
+                break;
+            }
+        }
+        try {
+            Jenkins.getInstance().getPlugin(PluginImpl.class).save();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        List<FailureCauseBuildAction> bfaActionList = run.getActions(FailureCauseBuildAction.class);
+        FoundFailureCause existingClaimedFoundFailureCause = null;
+        FailureCauseBuildAction bfaAction = bfaActionList.get(0);
+        List<FoundFailureCause> foundFailureCauses = bfaAction.getFoundFailureCauses();
+        boolean hasFailureCauseFromBFA = false;
+        for (FoundFailureCause cause : foundFailureCauses) {
+            // check if it's an indication created by claim
+            if(cause.getName().equals(newClaimedFailureCause.getName()) && cause.getIndications().get(0).getMatchingFile().equals("log")){
+                hasFailureCauseFromBFA = true;
+            }
+            if (cause.getIndications().get(0).getMatchingFile()==matchingFile) {
+                existingClaimedFoundFailureCause = cause;
+                break;
+            }
+        }
+        if (existingClaimedFoundFailureCause != null) {
+            foundFailureCauses.remove(existingClaimedFoundFailureCause);
+        }
+        if(!hasFailureCauseFromBFA) {
+            foundFailureCauses.add(newClaimedFailureCause);
+        }
+        try {
+            run.save();
+            StatisticsLogger.getInstance().log((AbstractBuild) run, bfaAction.getFoundFailureCauses());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void removeFailAction(Run run){
+        List<FailureCauseBuildAction> bfaActionList = run.getActions(FailureCauseBuildAction.class);
+        if(!bfaActionList.isEmpty()) {
+            FailureCauseBuildAction bfaAction = bfaActionList.get(0);
+            List<FoundFailureCause> foundFailureCauses = bfaAction.getFoundFailureCauses();
+            for (FoundFailureCause cause : foundFailureCauses) {
+                if (cause.getIndications().get(0).getMatchingFile() == "Claim") {
+                    foundFailureCauses.remove(cause);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/claim/ClaimIndication.java
+++ b/src/main/java/hudson/plugins/claim/ClaimIndication.java
@@ -1,0 +1,11 @@
+package hudson.plugins.claim;
+
+import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
+import hudson.model.AbstractBuild;
+
+public class ClaimIndication extends FoundIndication {
+
+    public ClaimIndication(AbstractBuild build, String originalPattern, String matchingFile, String matchingString) {
+        super(build, originalPattern, matchingFile, matchingString);
+    }
+}

--- a/src/main/java/hudson/plugins/claim/ClaimPublisher.java
+++ b/src/main/java/hudson/plugins/claim/ClaimPublisher.java
@@ -51,6 +51,7 @@ public class ClaimPublisher extends Notifier {
         if (build.getResult().isWorseThan(Result.SUCCESS)) {
             ClaimBuildAction action = new ClaimBuildAction(build);
             build.addAction(action);
+            build.save();
 
             // check if previous build was claimed
             AbstractBuild<?,?> previousBuild = build.getPreviousBuild();

--- a/src/main/java/hudson/plugins/claim/DescribableTestAction.java
+++ b/src/main/java/hudson/plugins/claim/DescribableTestAction.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedList;
 import java.util.List;
 
 public abstract class DescribableTestAction extends TestAction implements Describable<DescribableTestAction> {
@@ -48,7 +49,6 @@ public abstract class DescribableTestAction extends TestAction implements Descri
 			if (currentUser != null) {
 				items.add(currentUser.getDisplayName(), currentUser.getId());
 			}
-			
 			Collection<User> c = User.getAll();
 			if (c != null && currentUser != null) {
 				if (c.contains(currentUser)) {
@@ -65,8 +65,29 @@ public abstract class DescribableTestAction extends TestAction implements Descri
 			}
 
 			return items;
+		}
 
+		public ListBoxModel doFillErrorsItems() throws Exception {
+			ListBoxModel items = new ListBoxModel();
+			if (ClaimBuildFailureAnalyzer.isBFAEnabled()) {
+				LinkedList<String> list = ClaimBuildFailureAnalyzer.getDropdownList();
+				if (!AbstractClaimBuildAction.isReclaim) {
+					items.add("---None---", "Default");
+					for (String cause : list) {
+						items.add(cause, cause);
+					}
+				} else {
+					if (!ClaimBuildFailureAnalyzer.ERROR.equals("Default")) {
+						items.add(ClaimBuildFailureAnalyzer.ERROR, ClaimBuildFailureAnalyzer.ERROR);
+					}
+					items.add("---None---", "Default");
+					for (String cause : list) {
+						if (!cause.equals(ClaimBuildFailureAnalyzer.ERROR))
+							items.add(cause, cause);
+					}
+				}
+			}
+			return items;
 		}
 	}
-
 }

--- a/src/main/resources/hudson/plugins/claim/AbstractClaimBuildAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/claim/AbstractClaimBuildAction/summary.jelly
@@ -1,6 +1,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 
+    <script src="${resURL}/plugin/claim/JS/json2.js" type="text/javascript"></script>
     <script type="text/javascript">
         function ShowPopup(hoveritem)
         {
@@ -13,7 +14,20 @@
             hp = document.getElementById("claimHoverPopup");
             hp.style.display = "none";
         }
-    </script>
+
+        function Display(error)
+        {
+            reasonText = document.getElementById("errordesc");
+            var json = '${it.fillReason()}';
+            obj = JSON.parse(json);
+            if(error == "Default"){
+                reasonText.textContent = "";
+            } else{
+                reasonText.textContent = obj[error];
+            }
+            reasonText.readOnly = true;
+        }
+   </script>
 
     <t:summary icon="${rootUrl}/plugin/claim/icons/claim-48x48.png">
         <j:choose>
@@ -87,9 +101,17 @@
             <f:form method="post" action="claim/claim" name="claim">
                 <f:entry title="${%Assignee}" field="assignee" help="/plugin/claim/help-assignee.html">
                     <f:select />        
-                </f:entry>                
+                </f:entry>
+                <j:if test="${it.isBFAEnabled()}">
+                    <f:entry title="${%Error}" field="errors" help="/plugin/claim/help-errors.html">
+                        <f:select onChange="Display(this.value);"/>
+                    </f:entry>
+                    <f:entry title="${%Description}" help="/plugin/claim/help-description.html">
+                      <f:textarea name="errordesc" id="errordesc" value=""/>
+                  </f:entry>
+                </j:if>
                 <f:entry title="${%Reason}" help="/plugin/claim/help-reason.html">
-                    <f:textarea name="reason" value="${it.reason}"/>
+                    <f:textarea name="reason" id="reason" value="${it.reason}"/>
                 </f:entry>
                 <f:entry title="${%Sticky}" help="/plugin/claim/help-sticky.html"> 
                     <f:checkbox name="sticky" checked="${it.sticky}"/>

--- a/src/main/webapp/JS/json2.js
+++ b/src/main/webapp/JS/json2.js
@@ -1,0 +1,519 @@
+/*
+    json2.js
+    2015-05-03
+
+    Public Domain.
+
+    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+    See http://www.JSON.org/js.html
+
+
+    This code should be minified before deployment.
+    See http://javascript.crockford.com/jsmin.html
+
+    USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO
+    NOT CONTROL.
+
+
+    This file creates a global JSON object containing two methods: stringify
+    and parse. This file is provides the ES5 JSON capability to ES3 systems.
+    If a project might run on IE8 or earlier, then this file should be included.
+    This file does nothing on ES5 systems.
+
+        JSON.stringify(value, replacer, space)
+            value       any JavaScript value, usually an object or array.
+
+            replacer    an optional parameter that determines how object
+                        values are stringified for objects. It can be a
+                        function or an array of strings.
+
+            space       an optional parameter that specifies the indentation
+                        of nested structures. If it is omitted, the text will
+                        be packed without extra whitespace. If it is a number,
+                        it will specify the number of spaces to indent at each
+                        level. If it is a string (such as '\t' or '&nbsp;'),
+                        it contains the characters used to indent at each level.
+
+            This method produces a JSON text from a JavaScript value.
+
+            When an object value is found, if the object contains a toJSON
+            method, its toJSON method will be called and the result will be
+            stringified. A toJSON method does not serialize: it returns the
+            value represented by the name/value pair that should be serialized,
+            or undefined if nothing should be serialized. The toJSON method
+            will be passed the key associated with the value, and this will be
+            bound to the value
+
+            For example, this would serialize Dates as ISO strings.
+
+                Date.prototype.toJSON = function (key) {
+                    function f(n) {
+                        // Format integers to have at least two digits.
+                        return n < 10 
+                            ? '0' + n 
+                            : n;
+                    }
+
+                    return this.getUTCFullYear()   + '-' +
+                         f(this.getUTCMonth() + 1) + '-' +
+                         f(this.getUTCDate())      + 'T' +
+                         f(this.getUTCHours())     + ':' +
+                         f(this.getUTCMinutes())   + ':' +
+                         f(this.getUTCSeconds())   + 'Z';
+                };
+
+            You can provide an optional replacer method. It will be passed the
+            key and value of each member, with this bound to the containing
+            object. The value that is returned from your method will be
+            serialized. If your method returns undefined, then the member will
+            be excluded from the serialization.
+
+            If the replacer parameter is an array of strings, then it will be
+            used to select the members to be serialized. It filters the results
+            such that only members with keys listed in the replacer array are
+            stringified.
+
+            Values that do not have JSON representations, such as undefined or
+            functions, will not be serialized. Such values in objects will be
+            dropped; in arrays they will be replaced with null. You can use
+            a replacer function to replace those with JSON values.
+            JSON.stringify(undefined) returns undefined.
+
+            The optional space parameter produces a stringification of the
+            value that is filled with line breaks and indentation to make it
+            easier to read.
+
+            If the space parameter is a non-empty string, then that string will
+            be used for indentation. If the space parameter is a number, then
+            the indentation will be that many spaces.
+
+            Example:
+
+            text = JSON.stringify(['e', {pluribus: 'unum'}]);
+            // text is '["e",{"pluribus":"unum"}]'
+
+
+            text = JSON.stringify(['e', {pluribus: 'unum'}], null, '\t');
+            // text is '[\n\t"e",\n\t{\n\t\t"pluribus": "unum"\n\t}\n]'
+
+            text = JSON.stringify([new Date()], function (key, value) {
+                return this[key] instanceof Date 
+                    ? 'Date(' + this[key] + ')' 
+                    : value;
+            });
+            // text is '["Date(---current time---)"]'
+
+
+        JSON.parse(text, reviver)
+            This method parses a JSON text to produce an object or array.
+            It can throw a SyntaxError exception.
+
+            The optional reviver parameter is a function that can filter and
+            transform the results. It receives each of the keys and values,
+            and its return value is used instead of the original value.
+            If it returns what it received, then the structure is not modified.
+            If it returns undefined then the member is deleted.
+
+            Example:
+
+            // Parse the text. Values that look like ISO date strings will
+            // be converted to Date objects.
+
+            myData = JSON.parse(text, function (key, value) {
+                var a;
+                if (typeof value === 'string') {
+                    a =
+/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)Z$/.exec(value);
+                    if (a) {
+                        return new Date(Date.UTC(+a[1], +a[2] - 1, +a[3], +a[4],
+                            +a[5], +a[6]));
+                    }
+                }
+                return value;
+            });
+
+            myData = JSON.parse('["Date(09/09/2001)"]', function (key, value) {
+                var d;
+                if (typeof value === 'string' &&
+                        value.slice(0, 5) === 'Date(' &&
+                        value.slice(-1) === ')') {
+                    d = new Date(value.slice(5, -1));
+                    if (d) {
+                        return d;
+                    }
+                }
+                return value;
+            });
+
+
+    This is a reference implementation. You are free to copy, modify, or
+    redistribute.
+*/
+
+/*jslint 
+    eval, for, this 
+*/
+
+/*property
+    JSON, apply, call, charCodeAt, getUTCDate, getUTCFullYear, getUTCHours,
+    getUTCMinutes, getUTCMonth, getUTCSeconds, hasOwnProperty, join,
+    lastIndex, length, parse, prototype, push, replace, slice, stringify,
+    test, toJSON, toString, valueOf
+*/
+
+
+// Create a JSON object only if one does not already exist. We create the
+// methods in a closure to avoid creating global variables.
+
+if (typeof JSON !== 'object') {
+    JSON = {};
+}
+
+(function () {
+    'use strict';
+    
+    var rx_one = /^[\],:{}\s]*$/,
+        rx_two = /\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g,
+        rx_three = /"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g,
+        rx_four = /(?:^|:|,)(?:\s*\[)+/g,
+        rx_escapable = /[\\\"\u0000-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
+        rx_dangerous = /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g;
+
+    function f(n) {
+        // Format integers to have at least two digits.
+        return n < 10 
+            ? '0' + n 
+            : n;
+    }
+    
+    function this_value() {
+        return this.valueOf();
+    }
+
+    if (typeof Date.prototype.toJSON !== 'function') {
+
+        Date.prototype.toJSON = function () {
+
+            return isFinite(this.valueOf())
+                ? this.getUTCFullYear() + '-' +
+                        f(this.getUTCMonth() + 1) + '-' +
+                        f(this.getUTCDate()) + 'T' +
+                        f(this.getUTCHours()) + ':' +
+                        f(this.getUTCMinutes()) + ':' +
+                        f(this.getUTCSeconds()) + 'Z'
+                : null;
+        };
+
+        Boolean.prototype.toJSON = this_value;
+        Number.prototype.toJSON = this_value;
+        String.prototype.toJSON = this_value;
+    }
+
+    var gap,
+        indent,
+        meta,
+        rep;
+
+
+    function quote(string) {
+
+// If the string contains no control characters, no quote characters, and no
+// backslash characters, then we can safely slap some quotes around it.
+// Otherwise we must also replace the offending characters with safe escape
+// sequences.
+
+        rx_escapable.lastIndex = 0;
+        return rx_escapable.test(string) 
+            ? '"' + string.replace(rx_escapable, function (a) {
+                var c = meta[a];
+                return typeof c === 'string'
+                    ? c
+                    : '\\u' + ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
+            }) + '"' 
+            : '"' + string + '"';
+    }
+
+
+    function str(key, holder) {
+
+// Produce a string from holder[key].
+
+        var i,          // The loop counter.
+            k,          // The member key.
+            v,          // The member value.
+            length,
+            mind = gap,
+            partial,
+            value = holder[key];
+
+// If the value has a toJSON method, call it to obtain a replacement value.
+
+        if (value && typeof value === 'object' &&
+                typeof value.toJSON === 'function') {
+            value = value.toJSON(key);
+        }
+
+// If we were called with a replacer function, then call the replacer to
+// obtain a replacement value.
+
+        if (typeof rep === 'function') {
+            value = rep.call(holder, key, value);
+        }
+
+// What happens next depends on the value's type.
+
+        switch (typeof value) {
+        case 'string':
+            return quote(value);
+
+        case 'number':
+
+// JSON numbers must be finite. Encode non-finite numbers as null.
+
+            return isFinite(value) 
+                ? String(value) 
+                : 'null';
+
+        case 'boolean':
+        case 'null':
+
+// If the value is a boolean or null, convert it to a string. Note:
+// typeof null does not produce 'null'. The case is included here in
+// the remote chance that this gets fixed someday.
+
+            return String(value);
+
+// If the type is 'object', we might be dealing with an object or an array or
+// null.
+
+        case 'object':
+
+// Due to a specification blunder in ECMAScript, typeof null is 'object',
+// so watch out for that case.
+
+            if (!value) {
+                return 'null';
+            }
+
+// Make an array to hold the partial results of stringifying this object value.
+
+            gap += indent;
+            partial = [];
+
+// Is the value an array?
+
+            if (Object.prototype.toString.apply(value) === '[object Array]') {
+
+// The value is an array. Stringify every element. Use null as a placeholder
+// for non-JSON values.
+
+                length = value.length;
+                for (i = 0; i < length; i += 1) {
+                    partial[i] = str(i, value) || 'null';
+                }
+
+// Join all of the elements together, separated with commas, and wrap them in
+// brackets.
+
+                v = partial.length === 0
+                    ? '[]'
+                    : gap
+                        ? '[\n' + gap + partial.join(',\n' + gap) + '\n' + mind + ']'
+                        : '[' + partial.join(',') + ']';
+                gap = mind;
+                return v;
+            }
+
+// If the replacer is an array, use it to select the members to be stringified.
+
+            if (rep && typeof rep === 'object') {
+                length = rep.length;
+                for (i = 0; i < length; i += 1) {
+                    if (typeof rep[i] === 'string') {
+                        k = rep[i];
+                        v = str(k, value);
+                        if (v) {
+                            partial.push(quote(k) + (
+                                gap 
+                                    ? ': ' 
+                                    : ':'
+                            ) + v);
+                        }
+                    }
+                }
+            } else {
+
+// Otherwise, iterate through all of the keys in the object.
+
+                for (k in value) {
+                    if (Object.prototype.hasOwnProperty.call(value, k)) {
+                        v = str(k, value);
+                        if (v) {
+                            partial.push(quote(k) + (
+                                gap 
+                                    ? ': ' 
+                                    : ':'
+                            ) + v);
+                        }
+                    }
+                }
+            }
+
+// Join all of the member texts together, separated with commas,
+// and wrap them in braces.
+
+            v = partial.length === 0
+                ? '{}'
+                : gap
+                    ? '{\n' + gap + partial.join(',\n' + gap) + '\n' + mind + '}'
+                    : '{' + partial.join(',') + '}';
+            gap = mind;
+            return v;
+        }
+    }
+
+// If the JSON object does not yet have a stringify method, give it one.
+
+    if (typeof JSON.stringify !== 'function') {
+        meta = {    // table of character substitutions
+            '\b': '\\b',
+            '\t': '\\t',
+            '\n': '\\n',
+            '\f': '\\f',
+            '\r': '\\r',
+            '"': '\\"',
+            '\\': '\\\\'
+        };
+        JSON.stringify = function (value, replacer, space) {
+
+// The stringify method takes a value and an optional replacer, and an optional
+// space parameter, and returns a JSON text. The replacer can be a function
+// that can replace values, or an array of strings that will select the keys.
+// A default replacer method can be provided. Use of the space parameter can
+// produce text that is more easily readable.
+
+            var i;
+            gap = '';
+            indent = '';
+
+// If the space parameter is a number, make an indent string containing that
+// many spaces.
+
+            if (typeof space === 'number') {
+                for (i = 0; i < space; i += 1) {
+                    indent += ' ';
+                }
+
+// If the space parameter is a string, it will be used as the indent string.
+
+            } else if (typeof space === 'string') {
+                indent = space;
+            }
+
+// If there is a replacer, it must be a function or an array.
+// Otherwise, throw an error.
+
+            rep = replacer;
+            if (replacer && typeof replacer !== 'function' &&
+                    (typeof replacer !== 'object' ||
+                    typeof replacer.length !== 'number')) {
+                throw new Error('JSON.stringify');
+            }
+
+// Make a fake root object containing our value under the key of ''.
+// Return the result of stringifying the value.
+
+            return str('', {'': value});
+        };
+    }
+
+
+// If the JSON object does not yet have a parse method, give it one.
+
+    if (typeof JSON.parse !== 'function') {
+        JSON.parse = function (text, reviver) {
+
+// The parse method takes a text and an optional reviver function, and returns
+// a JavaScript value if the text is a valid JSON text.
+
+            var j;
+
+            function walk(holder, key) {
+
+// The walk method is used to recursively walk the resulting structure so
+// that modifications can be made.
+
+                var k, v, value = holder[key];
+                if (value && typeof value === 'object') {
+                    for (k in value) {
+                        if (Object.prototype.hasOwnProperty.call(value, k)) {
+                            v = walk(value, k);
+                            if (v !== undefined) {
+                                value[k] = v;
+                            } else {
+                                delete value[k];
+                            }
+                        }
+                    }
+                }
+                return reviver.call(holder, key, value);
+            }
+
+
+// Parsing happens in four stages. In the first stage, we replace certain
+// Unicode characters with escape sequences. JavaScript handles many characters
+// incorrectly, either silently deleting them, or treating them as line endings.
+
+            text = String(text);
+            rx_dangerous.lastIndex = 0;
+            if (rx_dangerous.test(text)) {
+                text = text.replace(rx_dangerous, function (a) {
+                    return '\\u' +
+                            ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
+                });
+            }
+
+// In the second stage, we run the text against regular expressions that look
+// for non-JSON patterns. We are especially concerned with '()' and 'new'
+// because they can cause invocation, and '=' because it can cause mutation.
+// But just to be safe, we want to reject all unexpected forms.
+
+// We split the second stage into 4 regexp operations in order to work around
+// crippling inefficiencies in IE's and Safari's regexp engines. First we
+// replace the JSON backslash pairs with '@' (a non-JSON character). Second, we
+// replace all simple value tokens with ']' characters. Third, we delete all
+// open brackets that follow a colon or comma or that begin the text. Finally,
+// we look to see that the remaining characters are only whitespace or ']' or
+// ',' or ':' or '{' or '}'. If that is so, then the text is safe for eval.
+
+            if (
+                rx_one.test(
+                    text
+                        .replace(rx_two, '@')
+                        .replace(rx_three, ']')
+                        .replace(rx_four, '')
+                )
+            ) {
+
+// In the third stage we use the eval function to compile the text into a
+// JavaScript structure. The '{' operator is subject to a syntactic ambiguity
+// in JavaScript: it can begin a block or an object literal. We wrap the text
+// in parens to eliminate the ambiguity.
+
+                j = eval('(' + text + ')');
+
+// In the optional fourth stage, we recursively walk the new structure, passing
+// each name/value pair to a reviver function for possible transformation.
+
+                return typeof reviver === 'function'
+                    ? walk({'': j}, '')
+                    : j;
+            }
+
+// If the text is not JSON parseable, then a SyntaxError is thrown.
+
+            throw new SyntaxError('JSON.parse');
+        };
+    }
+}());

--- a/src/main/webapp/help-description.html
+++ b/src/main/webapp/help-description.html
@@ -1,0 +1,3 @@
+<div>
+    The description of the selected failure cause from the BFA knowledgebase
+</div>

--- a/src/main/webapp/help-errors.html
+++ b/src/main/webapp/help-errors.html
@@ -1,0 +1,3 @@
+<div>
+    The error you would like to claim from BFA's KnowledgeBase
+</div>

--- a/src/test/java/hudson/plugins/claim/ClaimBFATest.java
+++ b/src/test/java/hudson/plugins/claim/ClaimBFATest.java
@@ -1,0 +1,157 @@
+package hudson.plugins.claim;
+
+import com.gargoylesoftware.htmlunit.html.HtmlButton;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlOption;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlSelect;
+import com.sonyericsson.jenkins.plugins.bfa.PluginImpl;
+import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
+import hudson.model.Build;
+import hudson.model.Project;
+import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
+import junit.framework.Assert;
+import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.FailureBuilder;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.HashSet;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.Assert.assertThat;
+
+public class ClaimBFATest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private Build<?, ?> build;
+    private Project<?, ?> project;
+
+    private static final String CAUSE_NAME_1 = "Cause1";
+    private static final String CAUSE_NAME_2 = "Cause2";
+    private static final String CAUSE_DESCRIPTION_1 = "DescriptionForCause1";
+    private static final String CAUSE_DESCRIPTION_2 = "DescriptionForCause2";
+    private static final String IDENTIFIED_PROBLEMS = "Identified problems";
+    private static final String REASON = "Test Reason";
+
+
+    @Before
+    public void setUp() throws Exception {
+        java.util.logging.Logger.getLogger("com.gargoylesoftware.htmlunit").setLevel(java.util.logging.Level.SEVERE);
+
+        j.jenkins.setAuthorizationStrategy(new FullControlOnceLoggedInAuthorizationStrategy());
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+
+        createKnowledgeBase();
+        project = j.createFreeStyleProject("x");
+        project.getBuildersList().add(new FailureBuilder());
+        project.getPublishersList().add(new ClaimPublisher());
+        build = project.scheduleBuild2(0).get();
+    }
+
+    @Test
+    public void canClaimFailureCause() throws Exception {
+        ClaimBuildAction action = applyClaimWithFailureCauseSelected("claim",CAUSE_NAME_2, REASON, CAUSE_DESCRIPTION_2);
+
+        assertThat(action.getClaimedBy(), is("user1"));
+        assertThat(action.getReason(), is(REASON));
+        assertThat(action.isClaimed(), is(true));
+        assertThat(action.isBFAEnabled(), is(true));
+
+        HtmlPage page = whenNavigatingtoClaimPage();
+        assertTrue(page.asXml().contains(IDENTIFIED_PROBLEMS));
+        assertTrue(page.asXml().contains(CAUSE_NAME_2));
+    }
+
+    @Test
+    public void canReclaimFailureCause() throws Exception{
+        applyClaimWithFailureCauseSelected("claim", CAUSE_NAME_2, REASON, CAUSE_DESCRIPTION_2);
+        ClaimBuildAction action = applyClaimWithFailureCauseSelected("reassign", CAUSE_NAME_1, REASON, CAUSE_DESCRIPTION_1);
+
+        assertThat(action.getClaimedBy(), is("user1"));
+        assertThat(action.getReason(), is(REASON));
+        assertThat(action.isClaimed(), is(true));
+        assertThat(action.isBFAEnabled(), is(true));
+
+        HtmlPage page = whenNavigatingtoClaimPage();
+        assertTrue(page.asXml().contains(IDENTIFIED_PROBLEMS));
+        assertTrue(page.asXml().contains(CAUSE_NAME_1));
+    }
+
+    @Test
+    public void canDropFailureCause() throws Exception{
+        ClaimBuildAction action = applyClaimWithFailureCauseSelected("claim", CAUSE_NAME_2, REASON, CAUSE_DESCRIPTION_2);
+
+        HtmlPage page = whenNavigatingtoClaimPage();
+        page.getElementById("dropClaim").click();
+        page = whenNavigatingtoClaimPage();
+        assertThat(action.isClaimed(), is(false));
+        assertTrue(page.asXml().contains(IDENTIFIED_PROBLEMS));
+        assertTrue(page.asXml().contains("No identified problem"));
+    }
+
+    @Test
+    public void testCreateKnowledgeBase() throws Exception {
+        createKnowledgeBase();
+        assertNotNull(PluginImpl.getInstance().getKnowledgeBase().getCauses());
+    }
+
+    @Test
+    public void errorDropdownIsPresentAndIsNotEmpty() throws Exception {
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login("user1", "user1");
+        HtmlPage page = wc.goTo("job/x/" + build.getNumber());
+        page.getElementById("claim").click();
+        HtmlForm form = page.getFormByName("claim");
+        HtmlSelect select = form.getSelectByName("_.errors");
+        HashSet<String> set = new HashSet<String>();
+        for(HtmlOption option:select.getOptions()){
+            set.add(option.getValueAttribute());
+        }
+        assertTrue(set.contains("Default"));
+        assertTrue(set.contains(CAUSE_NAME_2));
+        assertTrue(set.contains(CAUSE_NAME_1));
+    }
+
+    private void createKnowledgeBase() throws Exception {
+        FailureCause cause1 = new FailureCause(CAUSE_NAME_1, CAUSE_DESCRIPTION_1);
+        FailureCause cause2 = new FailureCause(CAUSE_NAME_2, CAUSE_DESCRIPTION_2);
+        PluginImpl.getInstance().getKnowledgeBase().addCause(cause1);
+        PluginImpl.getInstance().getKnowledgeBase().addCause(cause2);
+    }
+
+    private ClaimBuildAction applyClaimWithFailureCauseSelected(String element, String error, String reason, String description) throws Exception {
+        HtmlPage page = whenNavigatingtoClaimPage();
+        page.getElementById(element).click();
+        HtmlForm form = page.getFormByName("claim");
+        form.getTextAreaByName("reason").setText(reason);
+        HtmlSelect select = form.getSelectByName("_.errors");
+        HtmlOption option = select.getOptionByValue(error);
+        select.setSelectedAttribute(option, true);
+
+        assertEquals(description, form.getTextAreaByName("errordesc").getTextContent());
+
+        form.submit((HtmlButton) j.last(form.getHtmlElementsByTagName("button")));
+
+        ClaimBuildAction action = build.getAction(ClaimBuildAction.class);
+        return action;
+    }
+
+    private HtmlPage whenNavigatingtoClaimPage() throws Exception{
+        JenkinsRule.WebClient wc = j.createWebClient();
+        wc.login("user1", "user1");
+        HtmlPage page = wc.goTo("job/x/" + build.getNumber());
+        return page;
+    }
+
+}


### PR DESCRIPTION
…aim plugin

---
Given a failed build and Build-Failure-Analyzer is installed, the user is presented with
the defined failure causes in the BFA knowledgebase upon claiming. If a failure cause is selected,
the indication is stored by BFA.

-Add ClaimBuildFailureAnalyzer to allow claiming of failure causes
-Add dynamic dropdown box + text-field on UI to display failure causes
-Implement tests to verify new functionality

See JENKINS-28722