### PR TITLE
Support new version of build failure plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>com.sonyericsson.jenkins.plugins.bfa</groupId>
 			<artifactId>build-failure-analyzer</artifactId>
-			<version>1.13.0</version>
+			<version>1.16.0</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/src/main/java/hudson/plugins/claim/ClaimBuildFailureAnalyzer.java
+++ b/src/main/java/hudson/plugins/claim/ClaimBuildFailureAnalyzer.java
@@ -54,7 +54,7 @@ public class ClaimBuildFailureAnalyzer {
         List<FoundIndication> indications = new LinkedList<FoundIndication>();
         for(FailureCause cause : getFailureCauses()){
             if(cause.getName().equals(ERROR)) {
-                indications.add(new ClaimIndication((AbstractBuild) run,"Null",matchingFile,"Null"));
+                indications.add(new ClaimIndication( run,"Null",matchingFile,"Null"));
                 newClaimedFailureCause = new FoundFailureCause(cause, indications);
                 break;
             }

--- a/src/main/java/hudson/plugins/claim/ClaimIndication.java
+++ b/src/main/java/hudson/plugins/claim/ClaimIndication.java
@@ -2,10 +2,11 @@ package hudson.plugins.claim;
 
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 public class ClaimIndication extends FoundIndication {
 
-    public ClaimIndication(AbstractBuild build, String originalPattern, String matchingFile, String matchingString) {
-        super(build, originalPattern, matchingFile, matchingString);
+    public ClaimIndication(Run run, String originalPattern, String matchingFile, String matchingString) {
+        super(run, originalPattern, matchingFile, matchingString);
     }
 }


### PR DESCRIPTION
Hi,

Build failure plugin has updated the API recently so that claim plugin cannot work with build failure plugin together.

This commit will solve this problem.

Thanks.
