### PR TITLE
fix NPE when null email address returned

### DIFF
--- a/src/main/java/hudson/plugins/claim/ClaimEmailer.java
+++ b/src/main/java/hudson/plugins/claim/ClaimEmailer.java
@@ -61,7 +61,8 @@ public final class ClaimEmailer {
         ClaimConfig config = ClaimConfig.get();
         if (config.getSendEmails() && MAILER_LOADED) {
             MimeMessage msg = createMessage(assignee, assignedBy, build, reason, url);
-            if (msg != null) {
+            Address[] recipients = msg.getAllRecipients();
+            if (recipients != null && recipients.length > 0) {
                 Transport.send(msg);
             }
         }
@@ -84,10 +85,9 @@ public final class ClaimEmailer {
 
         msg.setText(text, mailDescriptor.getCharset());
         Address userEmail = getUserEmail(assignee, mailDescriptor);
-        if (userEmail == null) {
-            return null;
+        if (userEmail != null) {
+            msg.setRecipient(RecipientType.TO, userEmail);
         }
-        msg.setRecipient(RecipientType.TO, userEmail);
 
         return msg;
     }

--- a/src/main/java/hudson/plugins/claim/ClaimEmailer.java
+++ b/src/main/java/hudson/plugins/claim/ClaimEmailer.java
@@ -61,7 +61,9 @@ public final class ClaimEmailer {
         ClaimConfig config = ClaimConfig.get();
         if (config.getSendEmails() && MAILER_LOADED) {
             MimeMessage msg = createMessage(assignee, assignedBy, build, reason, url);
-            Transport.send(msg);
+            if (msg != null) {
+                Transport.send(msg);
+            }
         }
     }
 
@@ -81,7 +83,11 @@ public final class ClaimEmailer {
                 + Messages.ClaimEmailer_Details(getJenkinsLocationConfiguration().getUrl() + url);
 
         msg.setText(text, mailDescriptor.getCharset());
-        msg.setRecipient(RecipientType.TO, getUserEmail(assignee, mailDescriptor));
+        Address userEmail = getUserEmail(assignee, mailDescriptor);
+        if (userEmail == null) {
+            return null;
+        }
+        msg.setRecipient(RecipientType.TO, userEmail);
 
         return msg;
     }

--- a/src/test/java/hudson/plugins/claim/ClaimEmailerTest.java
+++ b/src/test/java/hudson/plugins/claim/ClaimEmailerTest.java
@@ -85,7 +85,7 @@ public class ClaimEmailerTest {
      * Test that method does not throw runtime exception if mail is null (can happen when user id contains spaces)
      */
     @Test
-    public void shouldNotFailWhenNullEmailAddress() throws Exception {
+    public void shouldNotFailWhenRecipientEmailAddressIsNull() throws Exception {
         // given
         JenkinsLocationConfiguration.get().setAdminAddress("test <test@test.com>");
         JenkinsLocationConfiguration.get().setUrl("localhost:8080/jenkins/");
@@ -93,6 +93,7 @@ public class ClaimEmailerTest {
         ClaimConfig config = ClaimConfig.get();
         config.setSendEmails(true);
 
+        // will generate invalid default mail address with a space
         User assignee = User.get("sarah connor", true, Collections.emptyMap());
 
         // when

--- a/src/test/java/hudson/plugins/claim/ClaimEmailerTest.java
+++ b/src/test/java/hudson/plugins/claim/ClaimEmailerTest.java
@@ -81,5 +81,26 @@ public class ClaimEmailerTest {
                 content.toString().contains(Messages.ClaimEmailer_Text("Test build", "assignedBy")));
     }
 
+    /*
+     * Test that method does not throw runtime exception if mail is null (can happen when user id contains spaces)
+     */
+    @Test
+    public void shouldNotFailWhenNullEmailAddress() throws Exception {
+        // given
+        JenkinsLocationConfiguration.get().setAdminAddress("test <test@test.com>");
+        JenkinsLocationConfiguration.get().setUrl("localhost:8080/jenkins/");
+
+        ClaimConfig config = ClaimConfig.get();
+        config.setSendEmails(true);
+
+        User assignee = User.get("sarah connor", true, Collections.emptyMap());
+
+        // when
+        ClaimEmailer.sendEmailIfConfigured(assignee, "assignedBy", "Test build", "test reason", "jobs/TestBuild/");
+
+        // then
+        // no exceptions
+    }
+
 
 }


### PR DESCRIPTION
if user id contains space, default email address cannot be calculated and null is returned. but recepient address cannot be null and we see NPE:
```
java.lang.NullPointerException
	at javax.mail.internet.InternetAddress.toString(InternetAddress.java:461)
	at javax.mail.internet.InternetAddress.toString(InternetAddress.java:426)
	at javax.mail.internet.MimeMessage.setAddressHeader(MimeMessage.java:707)
	at javax.mail.internet.MimeMessage.setRecipients(MimeMessage.java:586)
	at javax.mail.Message.setRecipient(Message.java:366)
	at hudson.plugins.claim.ClaimEmailer.createMessage(ClaimEmailer.java:84)
	at hudson.plugins.claim.ClaimEmailer.sendEmailIfConfigured(ClaimEmailer.java:63)
```