### PR TITLE
JENKINS-59204 Fix bfa compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 		<dependency>
 			<groupId>com.sonyericsson.jenkins.plugins.bfa</groupId>
 			<artifactId>build-failure-analyzer</artifactId>
-			<version>1.19.0</version>
+			<version>1.24.1-SNAPSHOT</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>3.32</version>
+		<version>3.51</version>
 		<relativePath />
 	</parent>
 
@@ -19,7 +19,7 @@
 		<developerConnection>scm:git:git@github.com:jenkinsci/claim-plugin.git</developerConnection>
 		<tag>${scmTag}</tag>
 	</scm>
-	
+
 	<developers>
 		<developer>
 			<id>ki82</id>
@@ -34,10 +34,22 @@
 	<properties>
 		<revision>2.16</revision>
 		<changelist>-SNAPSHOT</changelist>
-		<jenkins.version>2.7.3</jenkins.version>
+		<jenkins.version>2.138.4</jenkins.version>
 		<java.level>8</java.level>
 		<checkstyle.version>3.0.0</checkstyle.version>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.jenkins.tools.bom</groupId>
+				<artifactId>bom-2.138.x</artifactId>
+				<version>3</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<build>
 		<pluginManagement>
@@ -103,23 +115,19 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>script-security</artifactId>
-			<version>1.34</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>mailer</artifactId>
-			<version>1.20</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>junit</artifactId>
-			<version>1.20</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>matrix-project</artifactId>
-			<version>1.12</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sonyericsson.jenkins.plugins.bfa</groupId>
@@ -127,10 +135,10 @@
 			<version>1.19.0</version>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>credentials</artifactId>
-			<version>1.24</version>
 			<optional>true</optional>
 			<scope>test</scope>
 		</dependency>
@@ -148,20 +156,27 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
-			<artifactId>workflow-aggregator</artifactId>
-			<version>1.7</version>
+			<artifactId>workflow-job</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-cps</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-durable-task-step</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-basic-steps</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>1.10.19</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 		<dependency>
 			<groupId>com.sonyericsson.jenkins.plugins.bfa</groupId>
 			<artifactId>build-failure-analyzer</artifactId>
-			<version>1.24.1-SNAPSHOT</version>
+			<version>1.24.1-rc648.5440c7a8702d</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 		<dependency>
 			<groupId>com.sonyericsson.jenkins.plugins.bfa</groupId>
 			<artifactId>build-failure-analyzer</artifactId>
-			<version>1.24.1-rc648.5440c7a8702d</version>
+			<version>1.24.1</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/src/main/java/hudson/plugins/claim/ClaimBuildFailureAnalyzer.java
+++ b/src/main/java/hudson/plugins/claim/ClaimBuildFailureAnalyzer.java
@@ -7,6 +7,8 @@ import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
 import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
 import com.sonyericsson.jenkins.plugins.bfa.statistics.StatisticsLogger;
+import hudson.ExtensionList;
+import hudson.Plugin;
 import hudson.model.Run;
 import jenkins.model.Jenkins;
 
@@ -38,12 +40,16 @@ public final class ClaimBuildFailureAnalyzer {
     }
 
     public static Collection<FailureCause> getFailureCauses() throws Exception {
-        return Jenkins.getInstance().getPlugin(PluginImpl.class).getKnowledgeBase().getCauses();
+        return getPluginImpl().getKnowledgeBase().getCauses();
+    }
+
+    private static PluginImpl getPluginImpl() {
+        return ExtensionList.lookupSingleton(PluginImpl.class);
     }
 
     public static boolean isBFAEnabled() {
-        return (Jenkins.getInstance().getPlugin("build-failure-analyzer") != null
-                && Jenkins.getInstance().getPlugin(PluginImpl.class).isGlobalEnabled());
+        Plugin plugin = Jenkins.get().getPlugin("build-failure-analyzer");
+        return plugin != null && plugin.getWrapper().isActive() && getPluginImpl().isGlobalEnabled();
     }
 
     public static HashMap<String, String> getFillReasonMap() throws Exception {
@@ -72,11 +78,9 @@ public final class ClaimBuildFailureAnalyzer {
                 break;
             }
         }
-        try {
-            Jenkins.getInstance().getPlugin(PluginImpl.class).save();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+
+        getPluginImpl().save();
+
         List<FailureCauseBuildAction> bfaActionList = run.getActions(FailureCauseBuildAction.class);
         FoundFailureCause existingClaimedFoundFailureCause = null;
         FailureCauseBuildAction bfaAction = bfaActionList.get(0);


### PR DESCRIPTION
Build failure analyzer modernised it's plugin in order to be compatible with JCASC,
During that change it converted it's configuration class from a subclass of `Plugin` to a subclass of `GlobalConfiguration`

It also bumped it's minimum jenkins version to 2.138.4

I've tested this change with BFA installed and without, it worked fine in both cases

This PR requires:
https://github.com/jenkinsci/build-failure-analyzer-plugin/pull/119


cc @rsandell @TWestling @Greybird 