### PR TITLE
Remove unneeded buildPlugin configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,1 @@
-buildPlugin(
-  jenkinsVersions: [null, '2.150.1'],
-  findbugs: [
-    run: true,
-    archive: true,
-	unstableTotalAll: '0'],
-  checkstyle: [
-    run: true,
-	archive: true,
-	unstableTotalAll: '0']
-) 
+buildPlugin(jenkinsVersions: [null, '2.150.1']) 


### PR DESCRIPTION
Checkstyle and spotbugs are being enabled by default in https://github.com/jenkins-infra/pipeline-library/pull/121, (assuming that checkstyle is bound to a phase in the build directly, the task is no longer directly invoked)