### PR TITLE
add "unclaimed test failures" column

### DIFF
--- a/src/main/java/hudson/plugins/claim/UnclaimedTestfailuresColumn.java
+++ b/src/main/java/hudson/plugins/claim/UnclaimedTestfailuresColumn.java
@@ -1,0 +1,85 @@
+package hudson.plugins.claim;
+
+import hudson.views.ListViewColumnDescriptor;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixRun;
+import hudson.model.Job;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.tasks.test.AbstractTestResultAction;
+import hudson.tasks.test.TestResult;
+import hudson.views.ListViewColumn;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.Nonnull;
+
+public final class UnclaimedTestfailuresColumn extends ListViewColumn {
+
+    @DataBoundConstructor
+    public UnclaimedTestfailuresColumn() {
+    }
+
+    @Override
+    public String getColumnCaption() {
+        return Messages.UnclaimedTestfailuresColumn_ColumnCaption();
+    }
+
+    public UnclaimedTestfailuresColumnInformation getUnclaimedTestsInfo(Job<?, ?> job) {
+    	
+        AbstractTestResultAction<?> testResultAction = getTestResultAction(job);
+        
+        UnclaimedTestfailuresColumnInformation info = null;
+        if (testResultAction != null) {
+        	int nbClaimedFailures = 0;
+			List<? extends TestResult> failedTests = testResultAction.getFailedTests();
+			for (TestResult failedTest : failedTests) {
+				ClaimTestAction x = failedTest.getTestAction(ClaimTestAction.class);
+				if (x != null && x.isClaimed()) {
+					nbClaimedFailures++;
+				}
+			}
+
+    		info = new UnclaimedTestfailuresColumnInformation(testResultAction, nbClaimedFailures);
+        }
+        return info;
+    }
+
+	private AbstractTestResultAction<?> getTestResultAction(Job<?, ?> job) {
+		Run<?, ?> run = job.getLastCompletedBuild();
+		if (run != null) {
+			return run.getAction(AbstractTestResultAction.class);
+		}
+		return null;
+	}
+
+	@Extension
+    public static class DescriptorImpl extends ListViewColumnDescriptor {
+        @Override
+        public ListViewColumn newInstance(StaplerRequest req,
+                                          @Nonnull JSONObject formData) throws FormException {
+            return new UnclaimedTestfailuresColumn();
+        }
+
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return Messages.UnclaimedTestfailuresColumn_DisplayName();
+        }
+
+        @Override
+        public boolean shownByDefault() {
+            return false;
+        }
+
+    }
+
+}

--- a/src/main/java/hudson/plugins/claim/UnclaimedTestfailuresColumnInformation.java
+++ b/src/main/java/hudson/plugins/claim/UnclaimedTestfailuresColumnInformation.java
@@ -1,0 +1,26 @@
+package hudson.plugins.claim;
+
+import hudson.tasks.test.AbstractTestResultAction;
+
+public final class UnclaimedTestfailuresColumnInformation {
+
+	private int nbClaimedFailures;
+	private AbstractTestResultAction<?> testResultAction;
+
+	public UnclaimedTestfailuresColumnInformation(AbstractTestResultAction<?> testResultAction, int nbClaimedFailures) {
+		this.testResultAction = testResultAction;
+		this.nbClaimedFailures = nbClaimedFailures;
+	}
+
+	public int getNbClaimedFailures() {
+		return nbClaimedFailures;
+	}
+
+	public int getNbUnclaimedFailures() {
+		return testResultAction.getFailCount() - nbClaimedFailures;
+	}
+
+	public AbstractTestResultAction<?> getTestResultAction() {
+		return testResultAction;
+	}
+}

--- a/src/main/resources/hudson/plugins/claim/Messages.properties
+++ b/src/main/resources/hudson/plugins/claim/Messages.properties
@@ -4,6 +4,9 @@ ClaimBuildAction.Noun=build
 ClaimColumn.ColumnCaption=Claim
 ClaimColumn.DisplayName=Claim
 
+UnclaimedTestfailuresColumn.ColumnCaption=Unclaimed test failures
+UnclaimedTestfailuresColumn.DisplayName=Unclaimed test failures
+
 ClaimedBuildsReport.DisplayName=Claim Report
 ClaimPublisher.DisplayName=Allow broken build claiming
 

--- a/src/main/resources/hudson/plugins/claim/UnclaimedTestfailuresColumn/column.jelly
+++ b/src/main/resources/hudson/plugins/claim/UnclaimedTestfailuresColumn/column.jelly
@@ -1,0 +1,23 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
+  <j:set var="uti" value="${it.getUnclaimedTestsInfo(job)}"/>
+  <td>
+    <j:choose>
+      <j:when test="${uti == null}">
+        ${%N/A}
+      </j:when>
+      <j:when test="${uti.testResultAction.totalCount == 0}">
+        (${%no tests})
+      </j:when>
+      <j:when test="${uti.testResultAction.failCount == 0}">
+        <span tooltip="${%no_failed_test}">${%no_failures}</span>
+      </j:when>
+      <j:otherwise>
+        <a href="${rootURL}/${job.url}lastCompletedBuild/${uti.testResultAction.urlName}/" 
+        	tooltip="${%x_of_y_unclaimed(uti.nbUnclaimedFailures, uti.testResultAction.failCount)}">
+          ${uti.nbUnclaimedFailures}
+        </a>
+      </j:otherwise>  
+    </j:choose>
+  </td>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/claim/UnclaimedTestfailuresColumn/column.properties
+++ b/src/main/resources/hudson/plugins/claim/UnclaimedTestfailuresColumn/column.properties
@@ -1,0 +1,3 @@
+x_of_y_unclaimed={0} unclaimed test failures ({1} failed tests)
+no_failures=-
+no_failed_test=no failed test


### PR DESCRIPTION
This PR provides a new column with the count of unclaimed tests what is really useful to be sure all failed tests among all projects have been assigned

![view-with-unclaimed-tests-usage](https://user-images.githubusercontent.com/191450/97579518-732c5f80-19f2-11eb-80dc-1eab56d04dfe.png)
