### PR TITLE
Allow Users to Customize Their Email Notification Preferences

### DIFF
--- a/src/main/java/hudson/plugins/claim/ClaimConfig.java
+++ b/src/main/java/hudson/plugins/claim/ClaimConfig.java
@@ -62,6 +62,11 @@ public final class ClaimConfig extends GlobalConfiguration {
     private boolean emailDisplayedForAssigneesList;
 
     /**
+     * When enabled users can configure their email notification preferences
+     */
+    private boolean allowUsersToConfigureEmailPreferences;
+
+    /**
      * Groovy script to be run when a claim is changed.
      */
     @Deprecated
@@ -89,6 +94,7 @@ public final class ClaimConfig extends GlobalConfiguration {
         propagateToFollowingBuildsByDefault = formData.getBoolean("propagateToFollowingBuildsByDefault");
         sortUsersByFullName = formData.getBoolean("sortUsersByFullName");
         emailDisplayedForAssigneesList = formData.getBoolean("emailDisplayedForAssigneesList");
+        allowUsersToConfigureEmailPreferences = formData.getBoolean("allowUsersToConfigureEmailPreferences");
         setGroovyTrigger(req.bindJSON(SecureGroovyScript.class, formData.getJSONObject("groovyTrigger")));
         save();
         return super.configure(req, formData);
@@ -198,6 +204,14 @@ public final class ClaimConfig extends GlobalConfiguration {
      */
     public void setEmailDisplayedForAssigneesList(boolean emailDisplayedForAssigneesList) {
         this.emailDisplayedForAssigneesList = emailDisplayedForAssigneesList;
+    }
+
+    public boolean isAllowUsersToConfigureEmailPreferences() {
+        return allowUsersToConfigureEmailPreferences;
+    }
+
+    public void setAllowUsersToConfigureEmailPreferences(boolean allowUsersToConfigureEmailPreferences) {
+        this.allowUsersToConfigureEmailPreferences = allowUsersToConfigureEmailPreferences;
     }
 
     @NonNull

--- a/src/main/java/hudson/plugins/claim/ClaimEmailPreference.java
+++ b/src/main/java/hudson/plugins/claim/ClaimEmailPreference.java
@@ -35,6 +35,8 @@ public class ClaimEmailPreference extends UserProperty {
         return receiveRepeatedTestClaimEmail;
     }
 
+
+
     @Extension
     public static class DescriptorImpl extends hudson.model.UserPropertyDescriptor {
         @Override
@@ -46,5 +48,14 @@ public class ClaimEmailPreference extends UserProperty {
         public String getDisplayName() {
             return "Claim E-Mail Preferences";
         }
+
+        public boolean isAllowUsersToConfigureEmailPreferences() {
+            var config = ClaimConfig.get();
+            if (config == null) {
+                return false;
+            }
+            return config.isAllowUsersToConfigureEmailPreferences();
+        }
+
     }
 }

--- a/src/main/java/hudson/plugins/claim/ClaimEmailPreference.java
+++ b/src/main/java/hudson/plugins/claim/ClaimEmailPreference.java
@@ -1,0 +1,50 @@
+package hudson.plugins.claim;
+
+import hudson.Extension;
+import hudson.model.UserProperty;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class ClaimEmailPreference extends UserProperty {
+
+    private final boolean receiveInitialBuildClaimEmail;
+    private final boolean receiveInitialTestClaimEmail;
+    private final boolean receiveRepeatedBuildClaimEmail;
+    private final boolean receiveRepeatedTestClaimEmail;
+
+    @DataBoundConstructor
+    public ClaimEmailPreference(boolean receiveInitialBuildClaimEmail, boolean receiveInitialTestClaimEmail, boolean receiveRepeatedBuildClaimEmail, boolean receiveRepeatedTestClaimEmail) {
+        this.receiveInitialBuildClaimEmail = receiveInitialBuildClaimEmail;
+        this.receiveInitialTestClaimEmail = receiveInitialTestClaimEmail;
+        this.receiveRepeatedBuildClaimEmail = receiveRepeatedBuildClaimEmail;
+        this.receiveRepeatedTestClaimEmail = receiveRepeatedTestClaimEmail;
+    }
+
+    public boolean isReceiveInitialBuildClaimEmail() {
+        return receiveInitialBuildClaimEmail;
+    }
+
+    public boolean isReceiveInitialTestClaimEmail() {
+        return receiveInitialTestClaimEmail;
+    }
+
+    public boolean isReceiveRepeatedBuildClaimEmail() {
+        return receiveRepeatedBuildClaimEmail;
+    }
+
+    public boolean isReceiveRepeatedTestClaimEmail() {
+        return receiveRepeatedTestClaimEmail;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends hudson.model.UserPropertyDescriptor {
+        @Override
+        public UserProperty newInstance(hudson.model.User user) {
+            return new ClaimEmailPreference(true, true, true, true);  // Default: keine E-Mails
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Claim E-Mail Preferences";
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/claim/ClaimEmailer.java
+++ b/src/main/java/hudson/plugins/claim/ClaimEmailer.java
@@ -55,7 +55,7 @@ public final class ClaimEmailer {
                                                               String action, String reason, String url)
             throws MessagingException, IOException {
 
-        if (!isMailEnabledByUserPreference(claimedByUser, ClaimEmailPreference::isReceiveInitialBuildClaimEmail)) {
+        if (isAllowUsersToConfigureEmailPreferences() && !isMailEnabledByUserPreference(claimedByUser, ClaimEmailPreference::isReceiveInitialBuildClaimEmail)) {
             LOGGER.log(java.util.logging.Level.FINE, "Initial build claim emails not configured for user {0}", claimedByUser.getDisplayName());
             return;
         }
@@ -83,7 +83,7 @@ public final class ClaimEmailer {
                                                              String action, String reason, String url)
         throws MessagingException, IOException {
 
-        if (!isMailEnabledByUserPreference(claimedByUser, ClaimEmailPreference::isReceiveInitialTestClaimEmail)) {
+        if (isAllowUsersToConfigureEmailPreferences() && !isMailEnabledByUserPreference(claimedByUser, ClaimEmailPreference::isReceiveInitialTestClaimEmail)) {
             LOGGER.log(java.util.logging.Level.FINE, "Initial test claim emails not configured for user {0}", claimedByUser.getDisplayName());
             return;
         }
@@ -108,7 +108,7 @@ public final class ClaimEmailer {
     public static void sendRepeatedBuildClaimEmailIfConfigured(@Nonnull User claimedByUser, String action, String url)
         throws MessagingException, IOException {
 
-        if (!isMailEnabledByUserPreference(claimedByUser, ClaimEmailPreference::isReceiveRepeatedBuildClaimEmail)) {
+        if (isAllowUsersToConfigureEmailPreferences() && !isMailEnabledByUserPreference(claimedByUser, ClaimEmailPreference::isReceiveRepeatedBuildClaimEmail)) {
             LOGGER.log(java.util.logging.Level.FINE, "Repeated Build claim emails not configured for user {0}", claimedByUser.getDisplayName());
             return;
         }
@@ -133,7 +133,7 @@ public final class ClaimEmailer {
                                                               List<CaseResult> failedTests)
         throws MessagingException, IOException {
 
-        if (!isMailEnabledByUserPreference(claimedByUser, ClaimEmailPreference::isReceiveRepeatedTestClaimEmail)) {
+        if (isAllowUsersToConfigureEmailPreferences() && !isMailEnabledByUserPreference(claimedByUser, ClaimEmailPreference::isReceiveRepeatedTestClaimEmail)) {
             LOGGER.log(java.util.logging.Level.FINE, "Repeated test claim emails not configured for user {0}", claimedByUser.getDisplayName());
             return;
         }
@@ -148,6 +148,14 @@ public final class ClaimEmailer {
     @FunctionalInterface
     private interface EmailPreferenceChecker {
         boolean shouldSend(ClaimEmailPreference preference);
+    }
+
+    private static boolean isAllowUsersToConfigureEmailPreferences() {
+        var config = ClaimConfig.get();
+        if (config == null) {
+            return false;
+        }
+        return config.isAllowUsersToConfigureEmailPreferences();
     }
 
     private static boolean isMailEnabledByUserPreference(@Nonnull User user, EmailPreferenceChecker preferenceChecker) {

--- a/src/main/java/hudson/plugins/claim/messages/ClaimMessage.java
+++ b/src/main/java/hudson/plugins/claim/messages/ClaimMessage.java
@@ -21,7 +21,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 //TODO configurable formatting, through email-ext plugin
-abstract class ClaimMessage {
+public abstract class ClaimMessage {
 
     private static final Logger LOGGER = Logger.getLogger("claim-plugin");
     protected static final String LINE_SEPARATOR =  System.getProperty("line.separator");

--- a/src/main/resources/hudson/plugins/claim/ClaimConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/claim/ClaimConfig/config.jelly
@@ -9,6 +9,10 @@
              help="/plugin/claim/help-sendEmailsForStickyFailures.html">
         <f:checkbox/>
     </f:entry>
+    <f:entry title="${%AllowUsersToConfigureEmailPreferences}" field="allowUsersToConfigureEmailPreferences"
+             help="/plugin/claim/help-allowUsersToConfigureEmailPreferences.html">
+        <f:checkbox/>
+    </f:entry>
     <f:entry title="${%StickyByDefault}" field="stickyByDefault" help="/plugin/claim/help-stickyByDefault.html">
         <f:checkbox/>
     </f:entry>

--- a/src/main/resources/hudson/plugins/claim/ClaimConfig/config.properties
+++ b/src/main/resources/hudson/plugins/claim/ClaimConfig/config.properties
@@ -5,3 +5,4 @@ PropagateToFollowingBuildsByDefault=Make claim propagate to following failed bui
 SortUsersByFullName=Sort the users by their name rather than they ids when listing them
 DisplayEmailForAssigneesList=Display email address of users when listing assignees
 GroovyScript=The Groovy script to run when claims are changed
+AllowUsersToConfigureEmailPreferences=Allow users to configure email preferences

--- a/src/main/resources/hudson/plugins/claim/ClaimEmailPreference/config.jelly
+++ b/src/main/resources/hudson/plugins/claim/ClaimEmailPreference/config.jelly
@@ -1,16 +1,25 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <j:set var="userEmailPreferencesEnabled" value="${descriptor.allowUsersToConfigureEmailPreferences}" />
     <f:description>If global email notification is enabled you can modify your notification preferences</f:description>
-    <f:entry title="Receive initial Build Claim Emails?" field="receiveInitialBuildClaimEmail">
-        <f:checkbox />
-    </f:entry>
-    <f:entry title="Receive initial Test Claim Emails?" field="receiveInitialTestClaimEmail">
-        <f:checkbox />
-    </f:entry>
-    <f:entry title="Receive repeated Build Claim Emails?" field="receiveRepeatedBuildClaimEmail">
-        <f:checkbox />
-    </f:entry>
-    <f:entry title="Receive repeated Test Claim Emails?" field="receiveRepeatedTestClaimEmail">
-        <f:checkbox />
-    </f:entry>
+    <j:if test="${userEmailPreferencesEnabled == true}">
+        <f:entry title="Receive initial Build Claim Emails?" field="receiveInitialBuildClaimEmail">
+            <f:checkbox />
+        </f:entry>
+        <f:entry title="Receive initial Test Claim Emails?" field="receiveInitialTestClaimEmail">
+            <f:checkbox />
+        </f:entry>
+        <f:entry title="Receive repeated Build Claim Emails?" field="receiveRepeatedBuildClaimEmail">
+            <f:checkbox />
+        </f:entry>
+        <f:entry title="Receive repeated Test Claim Emails?" field="receiveRepeatedTestClaimEmail">
+            <f:checkbox />
+        </f:entry>
+    </j:if>
+    <j:if test="${userEmailPreferencesEnabled == false}">
+        <f:entry title="Email notifications are managed globally and cannot be configured.">
+            Your administrator has disabled user-specific email preferences.
+        </f:entry>
+    </j:if>
+
 </j:jelly>

--- a/src/main/resources/hudson/plugins/claim/ClaimEmailPreference/config.jelly
+++ b/src/main/resources/hudson/plugins/claim/ClaimEmailPreference/config.jelly
@@ -1,0 +1,16 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:description>If global email notification is enabled you can modify your notification preferences</f:description>
+    <f:entry title="Receive initial Build Claim Emails?" field="receiveInitialBuildClaimEmail">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="Receive initial Test Claim Emails?" field="receiveInitialTestClaimEmail">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="Receive repeated Build Claim Emails?" field="receiveRepeatedBuildClaimEmail">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="Receive repeated Test Claim Emails?" field="receiveRepeatedTestClaimEmail">
+        <f:checkbox />
+    </f:entry>
+</j:jelly>

--- a/src/main/webapp/help-allowUsersToConfigureEmailPreferences.html
+++ b/src/main/webapp/help-allowUsersToConfigureEmailPreferences.html
@@ -1,0 +1,3 @@
+<div>
+    Checking this option will enable your users to configure their own email notification preferences.
+</div>

--- a/src/main/webapp/help-sendEmails.html
+++ b/src/main/webapp/help-sendEmails.html
@@ -1,3 +1,4 @@
 <div>
  If selected, an email is sent to the assignee when a build is claimed or assigned. To enable sending emails, you need to also install the mailer plugin.
+ Users can customize their email settings in the account settings.
 </div>

--- a/src/test/java/hudson/plugins/claim/ClaimEmailPreferenceTest.java
+++ b/src/test/java/hudson/plugins/claim/ClaimEmailPreferenceTest.java
@@ -1,0 +1,75 @@
+package hudson.plugins.claim;
+
+import hudson.model.User;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.*;
+
+public class ClaimEmailPreferenceTest {
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    public void testDefaultEmailPreferences() {
+        User user = User.getOrCreateByIdOrFullName("testuser");
+
+        ClaimEmailPreference preference = user.getProperty(ClaimEmailPreference.class);
+
+        assertNotNull("User property should not be null", preference);
+        assertTrue("Default initial build claim email should be true", preference.isReceiveInitialBuildClaimEmail());
+        assertTrue("Default initial test claim email should be true", preference.isReceiveInitialTestClaimEmail());
+        assertTrue("Default repeated build claim email should be true", preference.isReceiveRepeatedBuildClaimEmail());
+        assertTrue("Default repeated test claim email should be true", preference.isReceiveRepeatedTestClaimEmail());
+    }
+
+    @Test
+    public void testCustomEmailPreferences() throws Exception {
+        User user = User.getOrCreateByIdOrFullName("testuser");
+
+        ClaimEmailPreference customPreference = new ClaimEmailPreference(true, false, true, false);
+        user.addProperty(customPreference);
+
+        ClaimEmailPreference preference = user.getProperty(ClaimEmailPreference.class);
+
+        assertNotNull("ClaimEmailPreference should be set", preference);
+        assertTrue("User should receive initial build claim emails", preference.isReceiveInitialBuildClaimEmail());
+        assertFalse("User should NOT receive initial test claim emails", preference.isReceiveInitialTestClaimEmail());
+        assertTrue("User should receive repeated build claim emails", preference.isReceiveRepeatedBuildClaimEmail());
+        assertFalse("User should NOT receive repeated test claim emails", preference.isReceiveRepeatedTestClaimEmail());
+    }
+
+    @Test
+    public void testUpdateEmailPreferences() throws Exception {
+        User user = User.getOrCreateByIdOrFullName("testuser");
+
+        user.addProperty(new ClaimEmailPreference(false, false, false, false));
+        ClaimEmailPreference pref1 = user.getProperty(ClaimEmailPreference.class);
+        assertFalse(pref1.isReceiveInitialBuildClaimEmail());
+        assertFalse(pref1.isReceiveInitialTestClaimEmail());
+        assertFalse(pref1.isReceiveRepeatedBuildClaimEmail());
+        assertFalse(pref1.isReceiveRepeatedTestClaimEmail());
+
+        user.addProperty(new ClaimEmailPreference(true, true, true, true));
+        ClaimEmailPreference pref2 = user.getProperty(ClaimEmailPreference.class);
+        assertTrue(pref2.isReceiveInitialBuildClaimEmail());
+        assertTrue(pref2.isReceiveInitialTestClaimEmail());
+        assertTrue(pref2.isReceiveRepeatedBuildClaimEmail());
+        assertTrue(pref2.isReceiveRepeatedTestClaimEmail());
+    }
+
+    @Test
+    public void testUserWithoutPreferences() {
+        User user = User.getOrCreateByIdOrFullName("newuser");
+
+        ClaimEmailPreference preference = user.getProperty(ClaimEmailPreference.class);
+
+        assertNotNull("Preference should not be null", preference);
+        assertTrue("Default initial build claim email should be true", preference.isReceiveInitialBuildClaimEmail());
+        assertTrue("Default initial test claim email should be true", preference.isReceiveInitialTestClaimEmail());
+        assertTrue("Default repeated build claim email should be true", preference.isReceiveRepeatedBuildClaimEmail());
+        assertTrue("Default repeated test claim email should be true", preference.isReceiveRepeatedTestClaimEmail());
+    }
+}

--- a/src/test/java/hudson/plugins/claim/ClaimEmailPreferenceTest.java
+++ b/src/test/java/hudson/plugins/claim/ClaimEmailPreferenceTest.java
@@ -72,4 +72,17 @@ public class ClaimEmailPreferenceTest {
         assertTrue("Default repeated build claim email should be true", preference.isReceiveRepeatedBuildClaimEmail());
         assertTrue("Default repeated test claim email should be true", preference.isReceiveRepeatedTestClaimEmail());
     }
+
+    @Test
+    public void testNullUserPreferences() {
+        User user = User.getOrCreateByIdOrFullName("noPreferencesUser");
+
+        ClaimEmailPreference preference = user.getProperty(ClaimEmailPreference.class);
+
+        assertNotNull("Preference should not be null", preference);
+        assertTrue("Default initial build claim email should be true", preference.isReceiveInitialBuildClaimEmail());
+        assertTrue("Default initial test claim email should be true", preference.isReceiveInitialTestClaimEmail());
+        assertTrue("Default repeated build claim email should be true", preference.isReceiveRepeatedBuildClaimEmail());
+        assertTrue("Default repeated test claim email should be true", preference.isReceiveRepeatedTestClaimEmail());
+    }
 }


### PR DESCRIPTION
Currently the plugin enable/disables the emails sent globally. With this PR I intend to let the User decide if an email should be sent or not. For Powerusers, like developers which work on a special core team it can become hard if they get 200 Emails a day. Making it possible to let the User decide enables them to unsubscribe from these emails. 


![grafik](https://github.com/user-attachments/assets/af58bf46-bf28-4d57-ba13-494056e0fa4f)


### Testing done

I've tested this plugin with hpi:run command

### Downsides
Please be aware that this could also raise false positive issues in this plugin when somebody claims that the email was not working but the user disables it from the user settings - Let me know if we may update some documentation or so?

### Notes
I can also add some tests - just wanted to hear your opinion on that PR first.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
