### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/src/main/java/hudson/plugins/claim/AbstractAssignedClaimsReport.java
+++ b/src/main/java/hudson/plugins/claim/AbstractAssignedClaimsReport.java
@@ -27,7 +27,7 @@ public class AbstractAssignedClaimsReport implements Action, IconSpec {
         Icon icon = IconSet.icons.getIconByClassSpec(iconClassName + " icon-md");
         if (icon != null) {
             JellyContext ctx = new JellyContext();
-            ctx.setVariable("resURL", Stapler.getCurrentRequest().getContextPath() + Jenkins.RESOURCE_PATH);
+            ctx.setVariable("resURL", Stapler.getCurrentRequest2().getContextPath() + Jenkins.RESOURCE_PATH);
             return icon.getQualifiedUrl(ctx);
         }
         return null;
@@ -60,7 +60,7 @@ public class AbstractAssignedClaimsReport implements Action, IconSpec {
     }
 
     public ModelObject getOwner() {
-        View view = Stapler.getCurrentRequest().findAncestorObject(View.class);
+        View view = Stapler.getCurrentRequest2().findAncestorObject(View.class);
         if (view != null) {
             return view;
         } else {

--- a/src/main/java/hudson/plugins/claim/AbstractClaimBuildAction.java
+++ b/src/main/java/hudson/plugins/claim/AbstractClaimBuildAction.java
@@ -8,8 +8,8 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -20,7 +20,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import javax.annotation.Nonnull;
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
@@ -70,7 +70,7 @@ public abstract class AbstractClaimBuildAction<T extends Saveable>
 
     // jelly
     @POST
-    public final void doClaim(StaplerRequest req, StaplerResponse resp)
+    public final void doClaim(StaplerRequest2 req, StaplerResponse2 resp)
             throws Exception {
         Jenkins.get().checkPermission(Jenkins.READ);
 
@@ -197,7 +197,7 @@ public abstract class AbstractClaimBuildAction<T extends Saveable>
 
     // jelly
     @POST
-    public final void doUnclaim(StaplerRequest req, StaplerResponse resp)
+    public final void doUnclaim(StaplerRequest2 req, StaplerResponse2 resp)
             throws ServletException, IOException {
         Jenkins.get().checkPermission(Jenkins.READ);
 

--- a/src/main/java/hudson/plugins/claim/ClaimColumn.java
+++ b/src/main/java/hudson/plugins/claim/ClaimColumn.java
@@ -12,7 +12,7 @@ import hudson.views.ListViewColumnDescriptor;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -67,7 +67,7 @@ public final class ClaimColumn extends ListViewColumn {
     @Extension
     public static class DescriptorImpl extends ListViewColumnDescriptor {
         @Override
-        public ListViewColumn newInstance(StaplerRequest req,
+        public ListViewColumn newInstance(StaplerRequest2 req,
                                           @NonNull JSONObject formData) throws FormException {
             return new ClaimColumn();
         }

--- a/src/main/java/hudson/plugins/claim/ClaimConfig.java
+++ b/src/main/java/hudson/plugins/claim/ClaimConfig.java
@@ -9,7 +9,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 @Extension
 public final class ClaimConfig extends GlobalConfiguration {
@@ -79,7 +79,7 @@ public final class ClaimConfig extends GlobalConfiguration {
     }
 
     @Override
-    public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+    public boolean configure(StaplerRequest2 req, JSONObject formData) throws FormException {
 
         // To persist global configuration information,
         // set that to properties and call save().

--- a/src/main/java/hudson/plugins/claim/ClaimTestDataPublisher.java
+++ b/src/main/java/hudson/plugins/claim/ClaimTestDataPublisher.java
@@ -13,7 +13,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import jakarta.mail.MessagingException;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.io.IOException;
 import java.util.*;

--- a/src/main/java/hudson/plugins/claim/UnclaimedTestFailuresColumn.java
+++ b/src/main/java/hudson/plugins/claim/UnclaimedTestFailuresColumn.java
@@ -10,7 +10,7 @@ import hudson.views.ListViewColumn;
 import hudson.views.ListViewColumnDescriptor;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.util.List;
 
@@ -55,7 +55,7 @@ public final class UnclaimedTestFailuresColumn extends ListViewColumn {
     @Extension
     public static class DescriptorImpl extends ListViewColumnDescriptor {
         @Override
-        public ListViewColumn newInstance(StaplerRequest req, @NonNull JSONObject formData) {
+        public ListViewColumn newInstance(StaplerRequest2 req, @NonNull JSONObject formData) {
             return new UnclaimedTestFailuresColumn();
         }
 

--- a/src/test/java/hudson/plugins/claim/ClaimGroovyTest.java
+++ b/src/test/java/hudson/plugins/claim/ClaimGroovyTest.java
@@ -15,8 +15,8 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -146,7 +146,7 @@ public class ClaimGroovyTest {
 
         try (ACLContext ctx = ACL.as(User.getOrCreateByIdOrFullName(ADMIN_WITH_NO_RUN_SCRIPT_RIGHTS))) {
             try {
-                StaplerRequest req = mock(StaplerRequest.class);
+                StaplerRequest2 req = mock(StaplerRequest2.class);
                 JSONObject jsonObject = new JSONObject();
                 jsonObject.accumulate("assignee", ADMIN_WITH_NO_RUN_SCRIPT_RIGHTS);
                 jsonObject.accumulate("reason", "none");
@@ -155,7 +155,7 @@ public class ClaimGroovyTest {
                 jsonObject.accumulate("propagateToFollowingBuilds", false);
                 when(req.getSubmittedForm()).thenReturn(jsonObject);
 
-                StaplerResponse res = mock(StaplerResponse.class);
+                StaplerResponse2 res = mock(StaplerResponse2.class);
                 ClaimBuildAction action = build.getAction(ClaimBuildAction.class);
                 action.doClaim(req, res);
             } catch (Exception e) {

--- a/src/test/java/hudson/plugins/claim/utils/TestBuilder.java
+++ b/src/test/java/hudson/plugins/claim/utils/TestBuilder.java
@@ -8,7 +8,7 @@ import hudson.model.Descriptor;
 import hudson.model.Result;
 import hudson.tasks.Builder;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.io.IOException;
 
@@ -39,7 +39,7 @@ public class TestBuilder extends Builder {
 
     @Extension
     public static final class DescriptorImpl extends Descriptor<Builder> {
-        public Builder newInstance(StaplerRequest req, JSONObject data) {
+        public Builder newInstance(StaplerRequest2 req, JSONObject data) {
             throw new UnsupportedOperationException();
         }
     }


### PR DESCRIPTION
Migrate from deprecated EE 8 functionality to non-deprecated EE 9 equivalents.

### Testing done

`mvn clean verify`