### PR TITLE
[JENKINS-75483] Drop the claim of a test fails with page not found

### DIFF
--- a/src/main/java/hudson/plugins/claim/ClaimTestAction.java
+++ b/src/main/java/hudson/plugins/claim/ClaimTestAction.java
@@ -1,6 +1,5 @@
 package hudson.plugins.claim;
 
-import hudson.Util;
 import hudson.model.Run;
 import hudson.model.User;
 import hudson.plugins.claim.ClaimTestDataPublisher.Data;
@@ -108,6 +107,6 @@ public final class ClaimTestAction extends AbstractClaimBuildAction<Run> {
     public String getAbsoluteUrl() {
         String baseUrl = getJenkinsBaseUrl();
         String jobUrl = data.getUrl() + "testReport/" + (this.testObjectId.startsWith("junit/") ? this.testObjectId.substring(6) : this.testObjectId);
-        return Util.rawEncode(baseUrl + jobUrl + '/');
+        return baseUrl + jobUrl + '/';
     }
 }


### PR DESCRIPTION
## [JENKINS-75483] Drop the claim of a test fails with page not found

[JENKINS-75483](https://issues.jenkins.io/browse/JENKINS-75483) reports cases where the user cannot drop the claim of a failing test.

This reverts commit 9b2d6670ff399da654a3a6e3301bf7e3d0dda91c.

### Testing done

Confirmed with interactive testing that the revert fixes [JENKINS-75483](https://issues.jenkins.io/browse/JENKINS-75483).

Without this fix, when I'm inside one of the test result pages that shows a "Drop the claim" link, a "not found" page is displayed when I click "Drop the claim".

With this fix, when I'm inside one of the test result pages that shows a "Drop the claim" link, the claim is dropped as expected.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
