### PR TITLE
Upgrade Mock JavaMail from 2.2 to 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,9 +184,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jvnet.mock-javamail</groupId>
+      <groupId>io.jenkins.lib</groupId>
       <artifactId>mock-javamail</artifactId>
-      <version>2.2</version>
+      <version>2.3</version>
       <scope>test</scope>
       <exclusions>
         <!-- Provided by jakarta-activation-api plugin -->


### PR DESCRIPTION
This library is now published on Maven Central with a new group ID.